### PR TITLE
Add LICENSE (MIT, following setup.py)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2009-2015 David Wilson <dw@botanicus.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
In order for python-pure-cdb to be packaged by a distribution like
Debian, it needs a clear license. Debian really needs python-pure-cdb
because the python-cdb package has been removed due to a lack of
licensing clarity there.

The setup.py file contains a `license='MIT'` line, from which I deduce
that the LICENSE file should contain the text of the MIT license. The
copyright date range I derived from the first and last commits.

It looks as if Daniel Néri dne@mayonnaise.net and Philippe
Ombredanne pom@nexb.com have contributed to this project. Getting an
Ack from them on this commit would be good.

Signed-off-by: Douglas Bagnall douglas@halo.gen.nz
