### PR TITLE
Quality control (flake8, Travis CI, and coveralls)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ python:
 
 install:
     - "pip install ."
-    - "pip install -U flake8"
+    - "pip install -U coveralls flake8"
 
 script:
-    - "python setup.py test"
+    - "coverage run --include='cdblib/*.py' setup.py test"
     - "flake8 ."
 
 notifications:
     - email: false
+
+after_success:
+    - "coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+
+language: "python"
+
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "3.7-dev"
+
+install:
+    - "pip install ."
+    - "pip install -U flake8"
+
+script:
+    - "python setup.py test"
+    - "flake8 ."
+
+notifications:
+    - email: false

--- a/cdblib/cdblib.py
+++ b/cdblib/cdblib.py
@@ -215,7 +215,7 @@ class Writer(object):
     def putstrings(self, key, values, encoding='utf-8'):
         '''Write zero or more unicode strings to the output file. Equivalent to
         calling putstring() in a loop.'''
-        self.puts(key, (six.text_type.encode(value, encoding) for value in values))
+        self.puts(key, (six.text_type.encode(v, encoding) for v in values))
 
     def finalize(self):
         '''Write the final hash tables to the output file, and write out its
@@ -238,7 +238,7 @@ class Writer(object):
         self.fp.seek(0)
         for pair in index:
             self.fp.write(self.write_pair(*pair))
-        self.fp = None # prevent double finalize()
+        self.fp = None  # prevent double finalize()
 
 
 class Writer64(Writer):

--- a/cdblib/cdbmake.py
+++ b/cdblib/cdbmake.py
@@ -35,7 +35,7 @@ class CdbMake(object):
     def parse_args(self, args):
         try:
             opts, args = getopt.gnu_getopt(args, 'p8')
-        except getopt.error as  e:
+        except getopt.error as e:
             self.usage(str(e))
 
         for opt, arg in opts:
@@ -67,11 +67,10 @@ class CdbMake(object):
             elif plus != '+':
                 self.die('bad or missing plus, line/record #%d', rec_nr)
 
-            bad = False
             try:
                 klen = int(''.join(iter(partial(read, 1), ',')), 10)
                 dlen = int(''.join(iter(partial(read, 1), ':')), 10)
-            except ValueError as e:
+            except ValueError:
                 self.die('bad or missing length, line/record #%d', rec_nr)
 
             key = read(klen)
@@ -118,4 +117,4 @@ def main(args=None, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr):
 
 
 if __name__ == '__main__':
-   main(sys.argv[1:])
+    main(sys.argv[1:])

--- a/cdblib/djb_hash.py
+++ b/cdblib/djb_hash.py
@@ -7,14 +7,14 @@ import six
 # iterating over byte strings differently.
 if six.PY2:
     def djb_hash(s):
-        '''Return the value of DJB's hash function for the given byte string.'''
+        '''Return the value of DJB's hash function for byte string *s*'''
         h = 5381
         for c in s:
             h = (((h << 5) + h) ^ ord(c)) & 0xffffffff
         return h
 else:
-    def djb_hash(s):
-        '''Return the value of DJB's hash function for the given byte string.'''
+    def djb_hash(s):  # noqa
+        '''Return the value of DJB's hash function for byte string *s*'''
         h = 5381
         for c in s:
             h = (((h << 5) + h) ^ c) & 0xffffffff
@@ -22,6 +22,6 @@ else:
 
 # If the C Extensions is available (Python 2 only), use it
 try:
-    from ._djb_hash import djb_hash
+    from ._djb_hash import djb_hash  # noqa
 except ImportError:
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+filename =
+    ./cdblib/*.py
+    ./setup.py

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
     ext_modules=ext_modules,
     install_requires=['six>=1.0.0,<2.0.0'],
     test_suite='tests',
-    tests_require=['flake8']
+    tests_require=['flake8'],
     entry_points={
         'console_scripts': ['python-pure-cdbmake=cdblib.cdbmake:main'],
-    }
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from os import environ
-from sys import version_info
 
 from setuptools import Extension, find_packages, setup
 

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,14 @@ if environ.get('ENABLE_DJB_HASH_CEXT'):
 else:
     ext_modules = []
 
+
+description = "Pure Python reader/writer for Dan J. Berstein's CDB format."
+
 setup(
     author='David Wilson',
     author_email='dw@botanicus.net',
-    description="Pure Python reader/writer for Dan J. Berstein's CDB format.",
+    description=description,
+    long_description=description,
     download_url='https://github.com/dw/python-pure-cdb',
     keywords='cdb file format appengine database db',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,13 @@ setup(
     keywords='cdb file format appengine database db',
     license='MIT',
     name='pure-cdb',
+    version='2.1.0',
     packages=find_packages(include=['cdblib']),
     ext_modules=ext_modules,
     install_requires=['six>=1.0.0,<2.0.0'],
     test_suite='tests',
-    version='2.1.0',
-    entry_points = {
+    tests_require=['flake8']
+    entry_points={
         'console_scripts': ['python-pure-cdbmake=cdblib.cdbmake:main'],
     }
 )

--- a/tests/cdblib_test.py
+++ b/tests/cdblib_test.py
@@ -40,7 +40,14 @@ class ReaderKnownGoodTestCase(unittest.TestCase):
             data = infile.read()
 
         for key, value in self.reader_cls(data).iteritems():
-            md5.update(b'+%d,%d:%s->%s\n' % (len(key), len(value), key, value))
+            # Hack to work around lack of bytes.format() in Python 3.4
+            data = '+{},{}:{}->{}\n'.format(
+                len(key),
+                len(value),
+                key.decode('utf-8'),
+                value.decode('utf-8')
+            )
+            md5.update(data.encode('utf-8'))
 
         md5.update(b'\n')
 


### PR DESCRIPTION
This PR:
* Adds `flake8` as a test dependency
* Cleans up the linting errors it finds in the main library directory and `setup.py` (mercifully few!)
* Adds a `.travils.yml` file for use with Travis CI
* Fixes an issue Travis caught with tests on Python 3.4
* Adds a hook for coveralls.io to report on coverage (one line un-covered by tests!)

You can see how it looks on [my fork](https://github.com/bbayles/python-pure-cdb/pull/4). @dw, if you're good with this perhaps you could enable the external services for this repo? My current access level doesn't permit me to do so.

The fix on 3.4 was the last thing I wanted to do before a first push to PyPI for Python 3. Once we're good here I'll build an `sdist` and `bdist_wheel` for Python 2 and 3, then put the files on the [releases page](https://github.com/dw/python-pure-cdb/releases) here on GitHub?