### PR TITLE
Remove the Python hash() references

### DIFF
--- a/cdblib/cdbmake.py
+++ b/cdblib/cdbmake.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-'''Python version of DJB's cdbmake, optionally supporting Python's hash().
+'''Python version of DJB's cdbmake. Supports standard 32-bit cdb files as
+well as 64-bit variants.
 
 Usage:
     cdbmake.py [-p] <output> <tmp>
 
 Where:
-    -p      Use Python hash() instead of standard DJB hash function.
     -8      Use cdblib.Writer64 rather than cdblib.Writer.
     output  Eventual destination path, must reside on same filesystem as tmp.
     tmp     Temporary file to use during write. Atomically replaces output at
@@ -28,7 +28,6 @@ class CdbMake(object):
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr
-        self.python_hash = False
         self.writer_cls = cdblib.Writer
         self.encoding = sys.getdefaultencoding()
 
@@ -39,9 +38,7 @@ class CdbMake(object):
             self.usage(str(e))
 
         for opt, arg in opts:
-            if opt == '-p':
-                self.python_hash = True
-            elif opt == '-8':
+            if opt == '-8':
                 self.writer_cls = cdblib.Writer64
 
         if len(args) != 2:
@@ -51,9 +48,8 @@ class CdbMake(object):
         self.tmp_filename = args[1]
 
     def begin(self):
-        hash_func = hash if self.python_hash else cdblib.djb_hash
         self.fp = io.open(self.tmp_filename, 'wb')
-        self.writer = self.writer_cls(self.fp, hash_func)
+        self.writer = self.writer_cls(self.fp)
 
     def parse_input(self):
         read = self.stdin.read

--- a/tests/cdblib_test.py
+++ b/tests/cdblib_test.py
@@ -253,18 +253,6 @@ class Reader64NativeInterfaceDjbHashTestCase(ReaderNativeInterfaceTestBase,
     HASHFN = staticmethod(cdblib.djb_hash)
 
 
-class ReaderNativeInterfaceNativeHashTestCase(ReaderNativeInterfaceTestBase,
-                                              unittest.TestCase):
-    HASHFN = staticmethod(hash)
-
-
-class Reader64NativeInterfaceNativeHashTestCase(ReaderNativeInterfaceTestBase,
-                                                unittest.TestCase):
-    reader_cls = cdblib.Reader64
-    writer_cls = cdblib.Writer64
-    HASHFN = staticmethod(hash)
-
-
 class ReaderNativeInterfaceNullHashTestCase(ReaderNativeInterfaceTestBase,
                                             unittest.TestCase):
     # Ensure collisions don't result in the wrong keys being returned.
@@ -373,18 +361,6 @@ class Writer64NativeInterfaceDjbHashTestCase(WriterNativeInterfaceTestBase,
     HASHFN = staticmethod(cdblib.djb_hash)
 
 
-class WriterNativeInterfaceNativeHashTestCase(WriterNativeInterfaceTestBase,
-                                              unittest.TestCase):
-    HASHFN = staticmethod(hash)
-
-
-class Writer64NativeInterfaceNativeHashTestCase(WriterNativeInterfaceTestBase,
-                                                unittest.TestCase):
-    reader_cls = cdblib.Reader64
-    writer_cls = cdblib.Writer64
-    HASHFN = staticmethod(hash)
-
-
 class WriterNativeInterfaceNullHashTestCase(WriterNativeInterfaceTestBase,
                                             unittest.TestCase):
     HASHFN = staticmethod(lambda s: 1)
@@ -465,34 +441,6 @@ class Writer64KnownGoodDjbHashTestCase(WriterKnownGoodTestBase,
     DUP_KEYS_MD5 = '1aae63d751ce5eea9e61916ae0aa00b3'
     TOP250PWS_MD5 = 'c6bdb3c7645c5d62747ac74895f9e90a'
     PWDUMP_MD5 = '3b1b4964294897c6ca119a6c6ae0094f'
-
-
-@unittest.skipIf(six.PY3, 'Python 3.3+ use random hash seeds')
-class WriterKnownGoodNativeHashTestCase(WriterKnownGoodTestBase,
-                                        unittest.TestCase):
-    HASHFN = staticmethod(hash)
-
-    EMPTY_MD5 = 'a646d6b87720195feb973de130b10123'
-    SINGLE_REC_MD5 = '9121969c106905e3fd72162c7bbb96a8'
-    DUP_KEYS_MD5 = '331840e761aee9092af6f8b0370b7d9a'
-    TOP250PWS_MD5 = 'e641b7b7d109b2daaa08335a1dc457c6'
-    PWDUMP_MD5 = 'd5726fc195460c9eef3117111975532f'
-
-
-@unittest.skipIf(six.PY3, 'Python 3.3+ use random hash seeds')
-class Writer64KnownGoodNativeHashTestCase(WriterKnownGoodTestBase,
-                                          unittest.TestCase):
-    HASHFN = staticmethod(hash)
-    reader_cls = cdblib.Reader64
-    writer_cls = cdblib.Writer64
-    top250_path = testdata_path('top250pws.cdb64')
-    pwdump_path = testdata_path('pwdump.cdb64')
-
-    EMPTY_MD5 = 'c43c406a037989703e0d58ed9f17ba3c'
-    SINGLE_REC_MD5 = 'fdd4a8c055d2000cba9b712ceb8a1eba'
-    DUP_KEYS_MD5 = '01e40b34cc51906f798233a2cd0fb09d'
-    TOP250PWS_MD5 = '3cd101954030b153584b620db5255b45'
-    PWDUMP_MD5 = 'a7275f527d54f51c10aebafaae1ab445'
 
 
 class WriterKnownGoodNullHashTestCase(WriterKnownGoodTestBase,

--- a/tests/cdblib_test.py
+++ b/tests/cdblib_test.py
@@ -7,6 +7,7 @@ import unittest
 
 from functools import partial
 from os.path import abspath, dirname, join
+from zlib import adler32
 
 import six
 
@@ -267,6 +268,20 @@ class Reader64NativeInterfaceNullHashTestCase(ReaderNativeInterfaceTestBase,
     HASHFN = staticmethod(lambda s: 1)
 
 
+class ReaderNativeInterfaceAltHashTestCase(ReaderNativeInterfaceTestBase,
+                                           unittest.TestCase):
+    # Use the adler32 checksum as a "hash"
+    HASHFN = staticmethod(lambda s: adler32(s) & 0xffffffff)
+
+
+class Reader64NativeInterfaceAltHashTestCase(ReaderNativeInterfaceTestBase,
+                                             unittest.TestCase):
+    reader_cls = cdblib.Reader64
+    writer_cls = cdblib.Writer64
+    # Use the adler32 checksum as a "hash"
+    HASHFN = staticmethod(lambda s: adler32(s) & 0xffffffff)
+
+
 class WriterNativeInterfaceTestBase(object):
     reader_cls = cdblib.Reader
     writer_cls = cdblib.Writer
@@ -371,6 +386,18 @@ class WriterNativeInterfaceNullHashTestCase(WriterNativeInterfaceTestBase,
     reader_cls = cdblib.Reader64
     writer_cls = cdblib.Writer64
     HASHFN = staticmethod(lambda s: 1)
+
+
+class WriterNativeInterfaceAltHashTestCase(WriterNativeInterfaceTestBase,
+                                           unittest.TestCase):
+    HASHFN = staticmethod(lambda s: adler32(s) & 0xffffffff)
+
+
+class WriterNativeInterfaceAltHashTestCase(WriterNativeInterfaceTestBase,
+                                           unittest.TestCase):
+    reader_cls = cdblib.Reader64
+    writer_cls = cdblib.Writer64
+    HASHFN = staticmethod(lambda s: adler32(s) & 0xffffffff)
 
 
 class WriterKnownGoodTestBase(object):


### PR DESCRIPTION
Re: issue #12, this PR zaps the tests with the built-in `hash()` function and the `-p` switch in `python-pure-cdbmake`.

I've added an example of swapping in a different "hash" function to the tests, the built-in `[zlib.adler32](https://docs.python.org/3/library/zlib.html#zlib.adler32)` checksum routine.