### PR TITLE
Better error message for string keys

### DIFF
--- a/cdblib/cdblib.py
+++ b/cdblib/cdblib.py
@@ -97,8 +97,14 @@ class Reader(object):
 
     def gets(self, key):
         '''Yield values for key in insertion order.'''
+        try:
+            h = self.hashfn(key) & 0xffffffff
+        except TypeError as e:
+            msg = 'key must be of type {}'
+            e.args = (msg.format(six.binary_type.__name__),)
+            raise
+
         # Truncate to 32 bits and remove sign.
-        h = self.hashfn(key) & 0xffffffff
         start, nslots = self.index[h & 0xff]
 
         if nslots:
@@ -187,7 +193,12 @@ class Writer(object):
 
     def put(self, key, value=b''):
         '''Write a string key/value pair to the output file.'''
-        assert type(key) is six.binary_type and type(value) is six.binary_type
+        if (
+            (not isinstance(key, six.binary_type)) or
+            (not isinstance(value, six.binary_type))
+        ):
+            msg = 'key and value must be of type {}'
+            raise TypeError(msg.format(six.binary_type.__name__))
 
         pos = self.fp.tell()
         self.fp.write(self.write_pair(len(key), len(value)))

--- a/cdblib/cdblib.py
+++ b/cdblib/cdblib.py
@@ -98,13 +98,13 @@ class Reader(object):
     def gets(self, key):
         '''Yield values for key in insertion order.'''
         try:
+            # Truncate to 32 bits and remove sign.
             h = self.hashfn(key) & 0xffffffff
         except TypeError as e:
             msg = 'key must be of type {}'
             e.args = (msg.format(six.binary_type.__name__),)
             raise
 
-        # Truncate to 32 bits and remove sign.
         start, nslots = self.index[h & 0xff]
 
         if nslots:


### PR DESCRIPTION
Re: issue #10, this PR changes the error output you get if you accidentally try to retrieve a text key.

Instead of `TypeError: unsupported operand type(s) for ^: 'int' and 'str'`, the new message is:
* Python 2: `TypeError: key must be of type str`
* Python 3: `TypeError: key must be of type bytes`

I'm making this change in lieu of dropping the `getstring`, `getint`, etc. methods in favor of the neat [adapter class](https://github.com/dw/python-pure-cdb/issues/10#issuecomment-425773154) stuff; still contemplating how much of that is worth doing.