### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+    - "pypy2.7-6.0"
+    - "pypy3.5-6.0"
 
 install:
     - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
-
+dist: xenial
 language: "python"
 
 python:
@@ -7,7 +6,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7-dev"
+    - "3.7"
 
 install:
     - "pip install ."


### PR DESCRIPTION
This PR drops the `sudo:false` directive - see [Travis's post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) and adds PyPy to the testing list.