### PR TITLE
Move to Python 3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ dist: xenial
 language: "python"
 
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"
-    - "pypy2.7-6.0"
     - "pypy3.5-6.0"
 
 install:
@@ -16,6 +14,7 @@ install:
 
 script:
     - "coverage run --include='cdblib/*.py' setup.py test"
+    - "ENABLE_DJB_HASH_CEXT=1 coverage run --include='cdblib/*.py' setup.py test"
     - "flake8 ."
 
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,14 @@ python-pure-cdb
     :target: https://python-pure-cdb.readthedocs.io/en/latest/?badge=latest
 
 The `python-pure-cdb` package (`pure-cdb <https://pypi.org/project/pure-cdb/>`_ on PyPI)
-is a Python library for working with D.J. Bernstein's "constant datbases."
-It supports Python 3.4 and above.
+is a Python library for working with D.J. Bernstein's "constant databases."
 
 In addition to being able to read and write the database files produced by
-other `cdb` tools, `python-pure-cdb` can produce and consume "64-bit"
+other `cdb` tools, this package can produce and consume "64-bit"
 constant databases that don't have the usual 4 GiB restriction.
+
+This package works with Python 3.4 and above.
+For a version that works with Python 2, see `this older release <https://github.com/dw/python-pure-cdb/releases/tag/v2.2.0>`_.
 
 For more information on constant databases, see `djb's page <https://cr.yp.to/cdb.html>`_
 and `Wikipedia <https://en.wikipedia.org/wiki/Cdb_(software)>`_.

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ python-pure-cdb
 
 The `python-pure-cdb` package (`pure-cdb <https://pypi.org/project/pure-cdb/>`_ on PyPI)
 is a Python library for working with D.J. Bernstein's "constant datbases."
-It supports both Python 2.7 and Python 3.
+It supports Python 3.4 and above.
 
 In addition to being able to read and write the database files produced by
 other `cdb` tools, `python-pure-cdb` can produce and consume "64-bit"

--- a/cdblib/__init__.py
+++ b/cdblib/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from .djb_hash import djb_hash
 from .cdblib import Reader, Reader64, Writer, Writer64
 

--- a/cdblib/_djb_hash.c
+++ b/cdblib/_djb_hash.c
@@ -1,15 +1,9 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
-#if PY_MAJOR_VERSION >= 3
-#   define MOD_RETURN(mod) return mod;
-#   define MODINIT_NAME PyInit__djb_hash
-#   define BUFFERLIKE_FMT "y#"
-#else
-#   define MOD_RETURN(mod) return;
-#   define MODINIT_NAME init_djb_hash
-#   define BUFFERLIKE_FMT "t#"
-#endif
+#define MOD_RETURN(mod) return mod;
+#define MODINIT_NAME PyInit__djb_hash
+#define BUFFERLIKE_FMT "y#"
 
 /* Return a Python long instance containing the value of the DJB hash function
  * for the given string or array. */
@@ -36,7 +30,6 @@ static /*const*/ PyMethodDef module_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_djb_hash",
@@ -48,16 +41,11 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-#endif
 
 PyMODINIT_FUNC
 MODINIT_NAME(void)
 {
-#if PY_MAJOR_VERSION >= 3
     PyObject *mod = PyModule_Create(&moduledef);
-#else
-    PyObject *mod = Py_InitModule3("_djb_hash", module_methods, "");
-#endif
 
     MOD_RETURN(mod);
 }

--- a/cdblib/cdbdump.py
+++ b/cdblib/cdbdump.py
@@ -1,9 +1,5 @@
-from __future__ import print_function
-
 import argparse
 import sys
-
-import six
 
 import cdblib
 
@@ -12,12 +8,12 @@ def cdbdump(parsed_args, **kwargs):
     # Read binary data from stdin by default
     stdin = kwargs.get('stdin')
     if stdin is None:
-        stdin = sys.stdin if six.PY2 else sys.stdin.buffer
+        stdin = sys.stdin.buffer
 
     # Print text data to stdout by default
     stdout = kwargs.get('stdout')
     if stdout is None:
-        stdout = sys.stdout if six.PY2 else sys.stdout.buffer
+        stdout = sys.stdout.buffer
 
     # Consume stdin and parse the cdb file
     reader_cls = cdblib.Reader64 if parsed_args['64'] else cdblib.Reader

--- a/cdblib/cdbmake.py
+++ b/cdblib/cdbmake.py
@@ -1,5 +1,4 @@
 import argparse
-import io
 import os
 import sys
 
@@ -89,7 +88,7 @@ class CDBMaker(object):
             yield key, data
 
     def run(self):
-        with io.open(self.cdb_temp_path, 'wb') as tmpfile:
+        with open(self.cdb_temp_path, 'wb') as tmpfile:
             with self.writer_cls(tmpfile) as writer:
                 for key, data in self.get_items():
                     writer.put(key, data)

--- a/cdblib/cdbmake.py
+++ b/cdblib/cdbmake.py
@@ -1,11 +1,7 @@
-from __future__ import print_function, unicode_literals
-
 import argparse
 import io
 import os
 import sys
-
-import six
 
 import cdblib
 
@@ -15,7 +11,7 @@ class CDBMaker(object):
         # Read binary data from stdin and write errors to stderr (by default)
         self.stdin = kwargs.get('stdin')
         if self.stdin is None:
-            self.stdin = sys.stdin if six.PY2 else sys.stdin.buffer
+            self.stdin = sys.stdin.buffer
 
         self.stderr = kwargs.get('stderr', sys.stderr)
 

--- a/cdblib/djb_hash.py
+++ b/cdblib/djb_hash.py
@@ -1,26 +1,13 @@
-from __future__ import unicode_literals
-
-import six
-
 # The cdb hash function is defined at: http://cr.yp.to/cdb/cdb.txt
-# We use separate implementations for Python 2 and 3, since they treat
-# iterating over byte strings differently.
-if six.PY2:
-    def djb_hash(s):
-        '''Return the value of DJB's hash function for byte string *s*'''
-        h = 5381
-        for c in s:
-            h = (((h << 5) + h) ^ ord(c)) & 0xffffffff
-        return h
-else:
-    def djb_hash(s):  # noqa
-        '''Return the value of DJB's hash function for byte string *s*'''
-        h = 5381
-        for c in s:
-            h = (((h << 5) + h) ^ c) & 0xffffffff
-        return h
+def djb_hash(s):  # noqa
+    '''Return the value of DJB's hash function for byte string *s*'''
+    h = 5381
+    for c in s:
+        h = (((h << 5) + h) ^ c) & 0xffffffff
+    return h
 
-# If the C Extensions is available (Python 2 only), use it
+
+# If the C Extension is available, use it
 try:
     from ._djb_hash import djb_hash  # noqa
 except ImportError:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'dw, bbayles'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.2.0'
+release = '3.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -119,9 +119,7 @@ Encoding and strict mode
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Database keys are stored as `bytes` objects. By default, `Reader` instances
-will attempt to convert text keys (`str` on Python 3, `unicode` on Python 2)
-and integer keys (`int` on Python 3, `int` and `long` on Python 2)
-automatically.
+will attempt to convert `str` keys and `int` keys automatically.
 
     >>> reader.get(b'1')  # Binary key
     b'value_for_1'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -35,7 +35,7 @@ To retrieve the first value stored at a key, use the `.get()` method.
     >>> reader.get(b'some_key')
     b'some_value'
 
-Note that all keys and values are `bytes` objects (`str` on Python 2).
+Note that all keys and values are `bytes` objects.
 For more information, see the library documentation.
 
 For "64-bit" database files, use `cdblib.Reader64` instead of `cdblib.Reader`.
@@ -53,7 +53,6 @@ Then write to the database with the `.put()` method.
    ...    with cdblib.Writer(f) as f:
    ...        writer.put(b'key', b'value')
 
-As with the reader class, all keys and values are `bytes` objects
-(`str` on Python 2).
+As with the reader class, all keys and values are `bytes` objects.
 
 For "64-bit" database files, use `cdblib.Writer64` instead of `cdblib.Writer`.

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,11 @@ setup(
     keywords='cdb file format appengine database db',
     license='MIT',
     name='pure-cdb',
-    version='3.0.0',
+    version='4.0.0',
     packages=find_packages(include=['cdblib']),
     ext_modules=ext_modules,
     install_requires=[],
+    python_requires='>=3.4',
     test_suite='tests',
     tests_require=['flake8'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import environ
 
 from setuptools import Extension, find_packages, setup
 
-# Opt-in to building the C extensions for Python 2 by setting the
+# Opt-in to building the C extension by setting the
 # ENABLE_DJB_HASH_CEXT environment variable
 if environ.get('ENABLE_DJB_HASH_CEXT'):
     ext_modules = [
@@ -24,10 +24,10 @@ setup(
     keywords='cdb file format appengine database db',
     license='MIT',
     name='pure-cdb',
-    version='2.2.0',
+    version='3.0.0',
     packages=find_packages(include=['cdblib']),
     ext_modules=ext_modules,
-    install_requires=['six>=1.0.0,<2.0.0'],
+    install_requires=[],
     test_suite='tests',
     tests_require=['flake8'],
     entry_points={

--- a/tests/cdblib_test.py
+++ b/tests/cdblib_test.py
@@ -34,7 +34,7 @@ class ReaderKnownGoodTestCase(unittest.TestCase):
     def reader_to_cdbmake_md5(self, filename):
         md5 = hashlib.md5()
 
-        with io.open(filename, 'rb') as infile:
+        with open(filename, 'rb') as infile:
             data = infile.read()
 
         for key, value in self.reader_cls(data).iteritems():
@@ -70,7 +70,7 @@ class ReaderDictLikeTestCase(unittest.TestCase):
     data_path = testdata_path('top250pws.cdb')
 
     def setUp(self):
-        with io.open(self.data_path, 'rb') as infile:
+        with open(self.data_path, 'rb') as infile:
             data = infile.read()
 
         self.reader = self.reader_cls(data)
@@ -481,7 +481,7 @@ class WriterKnownGoodTestBase(object):
         self.assertEqual(self.get_md5(), self.DUP_KEYS_MD5)
 
     def get_iteritems(self, filename):
-        with io.open(filename, 'rb') as infile:
+        with open(filename, 'rb') as infile:
             data = infile.read()
 
         reader = self.reader_cls(data, hashfn=self.HASHFN, strict=True)

--- a/tests/cdblib_test.py
+++ b/tests/cdblib_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import unicode_literals
-
 import hashlib
 import io
 import unittest
@@ -9,8 +7,6 @@ from functools import partial
 from os.path import abspath, dirname, join
 from struct import pack
 from zlib import adler32
-
-import six
 
 import cdblib
 
@@ -98,11 +94,11 @@ class ReaderDictLikeTestCase(unittest.TestCase):
 
     def test_iterkeys(self):
         for key in self.reader.iterkeys():
-            self.assertIs(type(self.reader[key]), six.binary_type)
+            self.assertIs(type(self.reader[key]), bytes)
 
     def test___iter__(self):
         for key in self.reader:
-            self.assertIs(type(self.reader[key]), six.binary_type)
+            self.assertIs(type(self.reader[key]), bytes)
 
     def test_values_itervalues(self):
         inverted = dict((v, k) for (k, v) in self.reader.iteritems())
@@ -226,7 +222,7 @@ class ReaderNativeInterfaceTestBase(object):
 
     def test_getstring(self):
         self.assertEqual(self.reader.getstring(b'art'), u'\N{SNOWMAN}')
-        self.assertEqual(type(self.reader.getstring(b'art')), six.text_type)
+        self.assertEqual(type(self.reader.getstring(b'art')), str)
         self.assertEqual(None, self.reader.getstring(b'junk'))
 
         self.assertEqual(
@@ -238,7 +234,7 @@ class ReaderNativeInterfaceTestBase(object):
         art_strings = tuple(self.reader.getstrings(b'art'))
         self.assertEqual(art_strings, self.ARTS)
         self.assertTrue(
-            all(type(s) is six.text_type for s in art_strings)
+            all(type(s) is str for s in art_strings)
         )
         self.assertEqual(list(self.reader.getstrings(b'junk')), [])
 
@@ -325,7 +321,7 @@ class WriterNativeInterfaceTestBase(object):
             (u'dave', lst, TypeError),
             (123, lst, TypeError),
             # Value is not binary
-            (b'dave',map(six.text_type, lst), TypeError),
+            (b'dave', map(str, lst), TypeError),
             (b'dave', (123,), TypeError),
         ]:
             with self.assertRaises(exc_type):
@@ -375,14 +371,15 @@ class WriterNativeInterfaceTestBase(object):
         self.assertEqual(self.get_reader().getstring(b'dave'), u'dave')
 
     def test_putstring_fail(self):
+        exc_types = (AttributeError, TypeError)
         for key, value, exc_type in [
             # Key is not binary
-            (u'dave', u'dave', TypeError),
-            (123, u'dave', TypeError),
+            (u'dave', u'dave', exc_types),
+            (123, u'dave', exc_types),
             # Value is not a string
-            (b'dave', 123, TypeError),
-            (b'dave', True, TypeError),
-            (b'dave', None, TypeError),
+            (b'dave', 123, exc_types),
+            (b'dave', True, exc_types),
+            (b'dave', None, exc_types),
         ]:
             with self.assertRaises(exc_type):
                 self.writer.putstring(key, value)
@@ -393,14 +390,15 @@ class WriterNativeInterfaceTestBase(object):
         self.assertEqual(list(self.get_reader().getstrings(b'dave')), lst)
 
     def test_putstrings_fail(self):
+        exc_types = (AttributeError, TypeError)
         for key, value, exc_type in [
             # Key is not binary
-            (u'dave', u'dave', TypeError),
-            (123, u'dave', TypeError),
+            (u'dave', u'dave', exc_types),
+            (123, u'dave', exc_types),
             # Value is not an iterable of strings
-            (b'dave', [u'123', 123], TypeError),
-            (b'dave', [u'123', True], TypeError),
-            (b'dave', [u'123', None], TypeError),
+            (b'dave', [u'123', 123], exc_types),
+            (b'dave', [u'123', True], exc_types),
+            (b'dave', [u'123', None], exc_types),
         ]:
             with self.assertRaises(exc_type):
                 self.writer.putstrings(key, value)

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import unicode_literals
-
 import filecmp
 import hashlib
 import io

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -39,7 +39,7 @@ class ScriptsTests(unittest.TestCase):
         args = [cdb_path, tmp_path]
         python_pure_cdbmake(args, stdin=stdin)
 
-        with io.open(cdb_path, 'rb') as infile:
+        with open(cdb_path, 'rb') as infile:
             data = infile.read()
             output_hash = hashlib.md5()
             output_hash.update(data)
@@ -139,7 +139,7 @@ class ScriptsTests(unittest.TestCase):
 
         python_pure_cdbmake(args, stdin=stdin)
 
-        with io.open(cdb_path, 'rb') as infile:
+        with open(cdb_path, 'rb') as infile:
             data = infile.read()
 
         reader = cdblib.Reader(data)
@@ -157,13 +157,13 @@ class ScriptsTests(unittest.TestCase):
         args = ['-64', cdb_path, tmp_path]
         python_pure_cdbmake(args, stdin=stdin)
 
-        with io.open(cdb_path, 'rb') as infile:
+        with open(cdb_path, 'rb') as infile:
             data = infile.read()
             output_hash = hashlib.md5()
             output_hash.update(data)
 
         # Ensure that everything can be decoded properly
-        with io.open(cdb_path, 'rb') as infile:
+        with open(cdb_path, 'rb') as infile:
             data = infile.read()
 
         reader = cdblib.Reader64(data)
@@ -175,7 +175,7 @@ class ScriptsTests(unittest.TestCase):
         # Dump a pre-made file to text and compare the output to what
         # is given by the official cdbdump tool
         top250_path = testdata_path('top250pws.cdb')
-        with io.open(top250_path, 'rb') as stdin:
+        with open(top250_path, 'rb') as stdin:
             with io.BytesIO() as stdout:
                 python_pure_cdbdump([], stdin=stdin, stdout=stdout)
                 data = stdout.getvalue()
@@ -192,7 +192,7 @@ class ScriptsTests(unittest.TestCase):
         # tool. Since the cdbdump is text, the 64-bit database should
         # produce the same input as the 32-bit database
         cdb_path = os.path.join(self.temp_dir, 'out_64.cdb')
-        with io.open(cdb_path, 'wb') as outfile:
+        with open(cdb_path, 'wb') as outfile:
             writer = cdblib.Writer64(outfile)
             writer.put(b'binary', b'\x81')
             writer.putstring(b'text', u'\U0001f574')
@@ -200,7 +200,7 @@ class ScriptsTests(unittest.TestCase):
             writer.putint(b'integer', 241)
             writer.finalize()
 
-        with io.open(cdb_path, 'rb') as stdin:
+        with open(cdb_path, 'rb') as stdin:
             with io.BytesIO() as stdout:
                 python_pure_cdbdump(['-64'], stdin=stdin, stdout=stdout)
                 data = stdout.getvalue()
@@ -218,7 +218,7 @@ class ScriptsTests(unittest.TestCase):
         make_args = ['-64'] if use_64 else []
         make_args += [cdb_path, tmp_path]
 
-        with io.open(path_to_dump, 'rb') as dump_in:
+        with open(path_to_dump, 'rb') as dump_in:
             with io.BytesIO() as dump_out:
                 python_pure_cdbdump(dump_args, stdin=dump_in, stdout=dump_out)
                 dump_out.seek(0)
@@ -246,7 +246,7 @@ class ScriptsTests(unittest.TestCase):
         with io.BytesIO(TYPES_DATA) as make_in:
             python_pure_cdbmake(make_args, stdin=make_in)
 
-        with io.open(cdb_path, 'rb') as dump_in:
+        with open(cdb_path, 'rb') as dump_in:
             with io.BytesIO() as dump_out:
                 python_pure_cdbdump(dump_args, stdin=dump_in, stdout=dump_out)
                 data = dump_out.getvalue()


### PR DESCRIPTION
Time is short for Python 2. This PR removes `six` and various Python 2-isms. Most of the changes were done by the [pyupgrade](https://github.com/asottile/pyupgrade) module, but I made a few others by hand.

In addition, Travis now exercises the C module.