### PR TITLE
python-cdb compatability module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@ constant databases that don't have the usual 4 GiB restriction.
 
 This package works with Python 3.4 and above.
 For a version that works with Python 2, see `this older release <https://github.com/dw/python-pure-cdb/releases/tag/v2.2.0>`_.
+To aid in porting `cdb` applications to Python 3, this library provides a
+compatability module for the `python-cdb <https://github.com/acg/python-cdb>`_
+package, which can act as a drop-in replacement (see `the docs <https://python-pure-cdb.readthedocs.io>`_).
 
 For more information on constant databases, see `djb's page <https://cr.yp.to/cdb.html>`_
 and `Wikipedia <https://en.wikipedia.org/wiki/Cdb_(software)>`_.

--- a/cdblib/compat.py
+++ b/cdblib/compat.py
@@ -1,5 +1,3 @@
-import atexit
-
 from itertools import chain, cycle, islice, repeat
 from mmap import mmap, ACCESS_READ
 from os import rename
@@ -27,8 +25,6 @@ class cdbmake:
         self.encoding = encoding
 
         self._temp_obj = open(self.fntmp, 'wb')
-        atexit.register(self._cleanup)
-
         self._writer = Writer(self._temp_obj, strict=True)
         self.numentries = 0
         self._finished = False
@@ -38,6 +34,9 @@ class cdbmake:
             self._temp_obj.close()
         except Exception:
             pass
+
+    def __del__(self):
+        self._cleanup()
 
     def add(self, key, data):
         """Store a record in the database.
@@ -90,7 +89,6 @@ class cdb:
 
         self._file_obj = open(self._file_path, mode='rb')
         self._mmap_obj = mmap(self._file_obj.fileno(), 0, access=ACCESS_READ)
-        atexit.register(self._cleanup)
         self._reader = Reader(self._mmap_obj)
 
         self._keys = self._get_key_iterator()
@@ -102,6 +100,9 @@ class cdb:
                 f.close()
             except Exception:
                 pass
+
+    def __del__(self):
+        self._cleanup()
 
     def _unique_keys(self, keys):
         seen = set()

--- a/cdblib/compat.py
+++ b/cdblib/compat.py
@@ -64,6 +64,9 @@ class cdbmake:
         """Finalize the database being written to. Then move the temporary
         database to its final location.
         """
+        if self._finished:
+            return
+
         self._writer.finalize()
         self._temp_obj.close()
         rename(self.fntmp, self.fn)

--- a/cdblib/compat.py
+++ b/cdblib/compat.py
@@ -106,10 +106,11 @@ class cdb:
     def __del__(self):
         self._cleanup()
 
-    def _unique_keys(self, keys):
+    def _unique_keys(self):
+        all_keys = (k for k, v in self._decoded_items())
         seen = set()
         seen_add = seen.add
-        for k in keys:
+        for k in all_keys:
             if k not in seen:
                 seen_add(k)
                 yield k
@@ -130,8 +131,7 @@ class cdb:
                 yield tuple(decoded_pair)
 
     def _get_key_iterator(self):
-        all_keys = (k for k, v in self._decoded_items())
-        unique_keys = self._unique_keys(all_keys)
+        unique_keys = self._unique_keys()
         return cycle(chain(unique_keys, repeat(None)))
 
     def each(self):
@@ -191,8 +191,7 @@ class cdb:
     def keys(self):
         """Return a list of the distinct keys stored in the database.
         """
-        all_keys = (k for k, v in self._decoded_items())
-        unique_keys = self._unique_keys(all_keys)
+        unique_keys = self._unique_keys()
         return list(unique_keys)
 
     @property

--- a/cdblib/compat.py
+++ b/cdblib/compat.py
@@ -1,0 +1,77 @@
+from itertools import islice
+from mmap import mmap, ACCESS_READ
+
+from .cdblib import Reader, Writer
+
+
+class cdbmake:
+    def __init__(self, cdb, tmp):
+        self.fn = cdb
+        self.fntmp = tmp
+
+    def add(self, key, data):
+        pass
+
+    def addmany(self, items):
+        pass
+
+    @property
+    def fd(self):
+        pass
+
+    def finish(self):
+        pass
+
+    @property
+    def numentries(self):
+        pass
+
+
+class cdb:
+    def __init__(self, f):
+        self._file_path = f
+        self._file_obj = open(self._file_path, mode='rb')
+        self._mmap_obj = open(self._file_obj.fileno(), 0, access=ACCESS_READ)
+        self._reader = Reader(self._mmap_obj)
+        self._keys = self._reader.iterkeys()
+        self._items = self._reader.iteritems()
+
+    def each():
+        ret = next(self._items, None)
+        if ret is None:
+            self._items = self._reader.iteritems()
+            ret = next(self._items, None)
+
+        return ret
+
+    @property
+    def fd(self):
+        return self._file_obj.fileno()
+
+    def firstkey(self):
+        return next(self._reader.iterkeys(), None)
+
+    def get(self, k, i=0):
+        it = next(islice(self._reader.gets(k), i, i + 1), None)
+
+    def getall(self, k):
+        return list(self._reader.gets(k))
+
+    def keys(self):
+        return self._reader.keys()
+
+    @property
+    def name(self):
+        return self._file_path
+
+    def nextkey(self):
+        ret = next(self._keys, None)
+        if ret is None:
+            self._items = self._reader.iterkeys()
+            ret = next(self._keys, None)
+
+        return ret
+
+    @property
+    def size(self):
+        return self._reader.length

--- a/cdblib/compat.py
+++ b/cdblib/compat.py
@@ -1,63 +1,109 @@
-from itertools import islice
+from itertools import chain, cycle, islice, repeat
 from mmap import mmap, ACCESS_READ
+from os import rename
 
 from .cdblib import Reader, Writer
 
 
 class cdbmake:
     def __init__(self, cdb, tmp):
+        """Create a new database to be stored at the path given by
+        *cdb*. Records will be written to the file at the path given by
+        *tmp*. After the ``finish()`` method is called, the file at *cdb*
+        will be replaced by the one at *tmp*.
+        """
+
         self.fn = cdb
         self.fntmp = tmp
 
+        self._temp_obj = open(self.fntmp, 'wb')
+        self._writer = Writer(self._temp_obj)
+        self.numentries = 0
+
     def add(self, key, data):
-        pass
+        """Store a record in the database.
+        """
+        self._writer.put(key, data)
+        self.numentries += 1
 
     def addmany(self, items):
-        pass
+        """Store each of the records in *items* in the the database.
+        *items* should be an iterable of ``(key, value)`` pairs.
+        """
+        for key, value in items:
+            self.add(key, value)
 
     @property
     def fd(self):
-        pass
+        return self._temp_obj.fileno()
 
     def finish(self):
-        pass
-
-    @property
-    def numentries(self):
-        pass
+        """Finalize the database being written to. Then move the temporary
+        database to its final location.
+        """
+        self._writer.finalize()
+        self._temp_obj.close()
+        rename(self.fntmp, self.fn)
 
 
 class cdb:
     def __init__(self, f):
         self._file_path = f
         self._file_obj = open(self._file_path, mode='rb')
-        self._mmap_obj = open(self._file_obj.fileno(), 0, access=ACCESS_READ)
+        self._mmap_obj = mmap(self._file_obj.fileno(), 0, access=ACCESS_READ)
         self._reader = Reader(self._mmap_obj)
-        self._keys = self._reader.iterkeys()
-        self._items = self._reader.iteritems()
 
-    def each():
-        ret = next(self._items, None)
-        if ret is None:
-            self._items = self._reader.iteritems()
-            ret = next(self._items, None)
+        self._keys = self._get_key_iterator()
+        self._items = cycle(self._reader.iteritems(), [None])
 
-        return ret
+    def _get_key_iterator(self):
+        return cycle(chain(self._reader.iterkeys(), repeat(None)))
+
+    def each(self):
+        """Return successive ``(key, value)`` tuples from the database.
+        After the last record is returned, the next call will return ``None``.
+        The call after that will return the first record again.
+        """
+
+        return next(self._items)
 
     @property
     def fd(self):
         return self._file_obj.fileno()
 
     def firstkey(self):
-        return next(self._reader.iterkeys(), None)
+        """Return the first key in the database.
+        If ``nextkey()`` is called after ``firstkey()``, the second key will
+        returned.
+        """
+
+        self._keys = self._get_key_iterator()
+        return next(self._keys)
 
     def get(self, k, i=0):
-        it = next(islice(self._reader.gets(k), i, i + 1), None)
+        """Return the ``i``-th value stored under the key given by ``k``.
+        If there are fewer than ``i`` items stored under key ``k``, return
+        ``None``.
+        """
+
+        return next(islice(self._reader.gets(k), i, i + 1), None)
+
+    def __getitem__(self, key):
+        value = self.get(key)
+        if value is None:
+            raise KeyError(key)
+
+        return value
 
     def getall(self, k):
+        """Return a list of the values stored under key ``k``.
+        """
+
         return list(self._reader.gets(k))
 
     def keys(self):
+        """Return a list of the distinct keys stored in the database.
+        """
         return self._reader.keys()
 
     @property
@@ -65,13 +111,20 @@ class cdb:
         return self._file_path
 
     def nextkey(self):
-        ret = next(self._keys, None)
-        if ret is None:
-            self._items = self._reader.iterkeys()
-            ret = next(self._keys, None)
+        """Return the next key in the datbase, or ``None`` if there are no more
+        keys to retrieve. Call ``firstkey()`` to start from the beginning
+        again.
+        """
 
-        return ret
+        return next(self._keys)
 
     @property
     def size(self):
         return self._reader.length
+
+
+def init(f):
+    """Return a ``cdb`` object based on the database stored at file path
+    *f*.
+    """
+    return cdb(f)

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -130,3 +130,26 @@ It also decodes text data when reading:
 `utf-8` encoding is used by default in `cdblib.compat.init()` and `cdblib.compat.cdbmake()`.
 Pass a different encoding with the `encoding` keyword argument to use a different scheme.
 Turn off automatic encoding or decoding by supplying `encoding=None`.
+All keys and values will be assumed to be `bytes` objects.
+
+    >>> existing_db = cdblib.compat.init(cdb_path, encoding=None)
+    >>> new_db = cdblib.compat.make(cdb_path, tmp_path, encoding=None)
+
+
+Other notes
+-----------
+
+The `python-cdb` package accepts integer file descriptors as well as file paths
+in `init()` and `cdbmake()`. This module does not.
+
+The `cdb` objects (returned by the `init()` function) and the `cdbmake` objects
+close their open file objects at interpreter exit.
+You may call the `._cleanup()` method on either one to close the objects
+yourself (this method is not avaialble when using the `python-cdb` package).
+
+The `cdb` object returned by the `init()` function uses `mmap.mmap` to avoid
+reading the whole database file into memory.
+This may be inappropriate when reading database files from certain locations,
+such as network drives.
+See the `Python docs <https://docs.python.org/3/library/mmap.html>`_ for more
+information on `mmap`.

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -1,0 +1,87 @@
+python-cdb compatibility module
+===============================
+
+`cdblib.compat` is designed to be used as a drop-in replacement for
+`python-cdb <https://github.com/acg/python-cdb>`_, a Python 2-only module for
+interacting with constant databases.
+
+To use it in your Python 3 application:
+
+.. code-block:: python
+
+    import cdblib.compat as cdb  # replaces import cdb
+
+
+Reading existing databases
+--------------------------
+
+The `init()` function accepts a path to an existing database file. It
+returns a `cdb` object that can be used to retrieve records from it.
+
+    >>> db = cdb.init('info.cdb')
+
+The `each()` method returns successive `(key, value)` pairs from the database.
+After the last record is returned the next call will return `None`.
+The call after that will return the first record again.
+
+    >>> db.each()
+    ('a', 'value_a1')
+    >>> db.each()
+    ('a', 'value_a2')
+    >>> db.each()
+    ('b', 'value_b1')
+    >>> db.each()  # No more records
+    >>> db.each()  # Loop around to the first record
+    ('a', 'value_a1')
+
+The `keys()` method returns a list of distinct keys from the database.
+
+    >>> db.keys()
+    ['a', 'b']
+
+The `cdb` object keeps an iterator over the distinct keys of the database.
+The `firstkey()` method resets the iterator and returns the first stored key.
+The `nextkey()` advances the iterator and returns the next key.
+After exhausting the iterator, `None` will be returned until `firstkey()` is
+called again.
+
+    >>> db.firstkey()
+    'a'
+    >>> db.nextkey()
+    'b'
+    >>> db.nextkey()  # No more keys
+    >>> db.firstkey()  # Reset the iterator
+    'a'
+
+Call the `get()` method with a key `k` and an optional index `i` to retrieve
+the `i`-th value stored under `k`. If there is no such value, `get()` returnes
+`None`.
+
+    >>> db.get('a')
+    'value_a1'
+    >>> db.get('a', 1)
+    'value_a2'
+    >>> db.get('a', 3)  # Returns None
+
+The `cdb` object can be accessed like a `dict` to retrieve the first value
+stored under a key. If there is no such key in the database, `KeyError` is
+raised.
+
+    >>> db['a']
+    'value_a1'
+    >>> db['b']
+    'value_b1'
+
+Call the `getall()` method to retrieve a list of the values stored under the
+key `k`.
+
+    >>> db.getall('a')
+    ['value_a1', 'value_a2']
+    >>> db.getall('b')
+    ['value_b1']
+    >>> db.getall('c')  # No such key, returns empty list
+    []
+
+The `cdb` object has a `size` property, which returns the total size of the
+database (in bytes). It also has a `name` property, which returns the path
+to the database file.

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -20,7 +20,7 @@ returns a `cdb` object that can be used to retrieve records from it.
 
     >>> db = cdb.init('info.cdb')
 
-The `each()` method returns successive `(key, value)` pairs from the database.
+The `.each()` method returns successive `(key, value)` pairs from the database.
 After the last record is returned the next call will return `None`.
 The call after that will return the first record again.
 
@@ -34,15 +34,15 @@ The call after that will return the first record again.
     >>> db.each()  # Loop around to the first record
     ('a', 'value_a1')
 
-The `keys()` method returns a list of distinct keys from the database.
+The `.keys()` method returns a list of distinct keys from the database.
 
     >>> db.keys()
     ['a', 'b']
 
 The `cdb` object keeps an iterator over the distinct keys of the database.
-The `firstkey()` method resets the iterator and returns the first stored key.
-The `nextkey()` advances the iterator and returns the next key.
-After exhausting the iterator, `None` will be returned until `firstkey()` is
+The `.firstkey()` method resets the iterator and returns the first stored key.
+The `.nextkey()` advances the iterator and returns the next key.
+After exhausting the iterator, `None` will be returned until `.firstkey()` is
 called again.
 
     >>> db.firstkey()
@@ -53,8 +53,8 @@ called again.
     >>> db.firstkey()  # Reset the iterator
     'a'
 
-Call the `get()` method with a key `k` and an optional index `i` to retrieve
-the `i`-th value stored under `k`. If there is no such value, `get()` returnes
+Call the `.get()` method with a key `k` and an optional index `i` to retrieve
+the `i`-th value stored under `k`. If there is no such value, `.get()` returnes
 `None`.
 
     >>> db.get('a')
@@ -72,7 +72,7 @@ raised.
     >>> db['b']
     'value_b1'
 
-Call the `getall()` method to retrieve a list of the values stored under the
+Call the `.getall()` method to retrieve a list of the values stored under the
 key `k`.
 
     >>> db.getall('a')
@@ -85,3 +85,48 @@ key `k`.
 The `cdb` object has a `size` property, which returns the total size of the
 database (in bytes). It also has a `name` property, which returns the path
 to the database file.
+
+
+Writing new databases
+---------------------
+
+The `cdbmake()` class is used to create a new database. Call it with two
+file paths: the first is the ultimate location of the database.
+temporary location to use when creating the database.
+It will be moved to the ultimate location after completion.
+
+    >>> cdb_path = '/tmp/info.cdb'
+    >>> tmp_path = cdb_path + '.tmp'
+    >>> db = cdbmake(cdb_path, tmp_path)
+
+Add records to the database with the `.add()` or `.addmany()` methods.
+
+    >>> db.add('b', 'value_b1')
+    >>> db.addmany([('a', 'value_a1'), ('a', 'value_a2')])
+
+Write the database structure to disk and rename the temporary file to the
+ultimate file with the `.finish()` method.
+
+
+Notes on encoding
+-----------------
+
+Since `python-cdb` is a Python 2-only module, it does not distinguish between
+text and binary keys or values.
+
+In order to handle `str` keys and values, `cdblib.compat` encodes text data
+on the way into the database:
+
+    >>> new_db.add('text_key', b'\x80 binary data')  # Key is encoded to binary
+    >>> new_db.add(b'\x80 binary key', 'text_data')  # Value is encoded to binary
+
+It also decodes text data when reading:
+
+    >>> existing_db.get(b'\x80 binary key')  # Text value is decoded
+    'text_data'
+    >>> existing_db.get('text_key')  # Binary value is left alone
+    b'\x80 binary data'
+
+`utf-8` encoding is used by default in `cdblib.compat.init()` and `cdblib.compat.cdbmake()`.
+Pass a different encoding with the `encoding` keyword argument to use a different scheme.
+Turn off automatic encoding or decoding by supplying `encoding=None`.

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -143,7 +143,7 @@ The `python-cdb` package accepts integer file descriptors as well as file paths
 in `init()` and `cdbmake()`. This module does not.
 
 The `cdb` objects (returned by the `init()` function) and the `cdbmake` objects
-close their open file objects at interpreter exit.
+close their open file objects when they are garbage collected.
 You may call the `._cleanup()` method on either one to close the objects
 yourself (this method is not avaialble when using the `python-cdb` package).
 

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -41,7 +41,7 @@ The `.keys()` method returns a list of distinct keys from the database.
 
 The `cdb` object keeps an iterator over the distinct keys of the database.
 The `.firstkey()` method resets the iterator and returns the first stored key.
-The `.nextkey()` advances the iterator and returns the next key.
+`.nextkey()` advances the iterator and returns the next key.
 After exhausting the iterator, `None` will be returned until `.firstkey()` is
 called again.
 
@@ -91,9 +91,8 @@ Writing new databases
 ---------------------
 
 The `cdbmake()` class is used to create a new database. Call it with two
-file paths: the first is the ultimate location of the database.
-temporary location to use when creating the database.
-It will be moved to the ultimate location after completion.
+file paths: (1) the ultimate location of the database,
+(2) a temporary location to use when creating the database.
 
     >>> cdb_path = '/tmp/info.cdb'
     >>> tmp_path = cdb_path + '.tmp'
@@ -128,7 +127,8 @@ It also decodes text data when reading:
     b'\x80 binary data'
 
 `utf-8` encoding is used by default in `cdblib.compat.init()` and `cdblib.compat.cdbmake()`.
-Pass a different encoding with the `encoding` keyword argument to use a different scheme.
+Pass a different encoding with the `encoding` keyword argument.
+
 Turn off automatic encoding or decoding by supplying `encoding=None`.
 All keys and values will be assumed to be `bytes` objects.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Contents
 
    quickstart.rst
    library.rst
+   compat.rst
    cli.rst
    versions.rst
    development.rst

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -17,7 +17,7 @@ from tests.cdblib_test import testdata_path
 class CompatTests(unittest.TestCase):
     def setUp(self):
         self.temp_dir = mkdtemp()
-        self.cdb_path = join(self.temp_dir, 'database.cd')
+        self.cdb_path = join(self.temp_dir, 'database.cdb')
         self.tmp_path = join(self.temp_dir, 'database.tmp')
 
         self.db = cdb.cdbmake(
@@ -50,32 +50,44 @@ class CompatTests(unittest.TestCase):
 
     def test_each(self):
         reader = self._get_reader()
-        self.assertEqual(reader.each(), ('a', '1'))
-        self.assertEqual(reader.each(), ('a', '2'))
-        self.assertEqual(reader.each(), ('b', '1'))
-        self.assertEqual(reader.each(), ('c', '1'))
-        self.assertEqual(reader.each(), ('a', b'\x80'))
-        self.assertIsNone(reader.each())
-        self.assertEqual(reader.each(), ('a', '1'))
+        try:
+            self.assertEqual(reader.each(), ('a', '1'))
+            self.assertEqual(reader.each(), ('a', '2'))
+            self.assertEqual(reader.each(), ('b', '1'))
+            self.assertEqual(reader.each(), ('c', '1'))
+            self.assertEqual(reader.each(), ('a', b'\x80'))
+            self.assertIsNone(reader.each())
+            self.assertEqual(reader.each(), ('a', '1'))
+        finally:
+            reader._file_obj.close()
 
     def test_firstkey(self):
         reader = self._get_reader()
-        self.assertEqual(reader.firstkey(), 'a')
-        self.assertEqual(reader.nextkey(), 'b')
-        self.assertEqual(reader.firstkey(), 'a')
-        self.assertEqual(reader.nextkey(), 'b')
+        try:
+            self.assertEqual(reader.firstkey(), 'a')
+            self.assertEqual(reader.nextkey(), 'b')
+            self.assertEqual(reader.firstkey(), 'a')
+            self.assertEqual(reader.nextkey(), 'b')
+        finally:
+            reader._file_obj.close()
 
     def test_nextkey(self):
         reader = self._get_reader()
-        self.assertEqual(reader.nextkey(), 'a')
-        self.assertEqual(reader.nextkey(), 'b')
-        self.assertEqual(reader.nextkey(), 'c')
-        self.assertIsNone(reader.nextkey())
-        self.assertIsNone(reader.nextkey())
+        try:
+            self.assertEqual(reader.nextkey(), 'a')
+            self.assertEqual(reader.nextkey(), 'b')
+            self.assertEqual(reader.nextkey(), 'c')
+            self.assertIsNone(reader.nextkey())
+            self.assertIsNone(reader.nextkey())
+        finally:
+            reader._file_obj.close()
 
     def test_size(self):
         reader = self._get_reader()
-        self.assertEqual(reader.size, 2178)
+        try:
+            self.assertEqual(reader.size, 2178)
+        finally:
+            reader._file_obj.close()
 
 
 if __name__ == '__main__':

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -8,13 +8,15 @@ from tempfile import mkdtemp
 
 try:
     import cdb
+    test_cdb = True
 except ImportError:
     import cdblib.compat as cdb
+    test_cdb = False
 
 from tests.cdblib_test import testdata_path
 
 
-class CompatTests(unittest.TestCase):
+class CompatTests(object):
     def setUp(self):
         self.temp_dir = mkdtemp()
         self.cdb_path = join(self.temp_dir, 'database.cdb')
@@ -100,8 +102,18 @@ class CompatTests(unittest.TestCase):
 
     def test_name_size(self):
         reader = self._get_reader()
-        self.assertEqual(reader.name, self.cdb_path)
+        self.assertEqual(reader.name.decode('utf-8'), self.cdb_path)
         self.assertEqual(reader.size, 2178)
+
+
+@unittest.skipIf(not test_cdb, 'Tests for Python 2 module')
+class PythonCDBTests(CompatTests, unittest.TestCase):
+    pass
+
+
+@unittest.skipIf(test_cdb, 'Tests for Python 3 module')
+class PythonPureCDBTests(CompatTests, unittest.TestCase):
+    pass
 
 
 if __name__ == '__main__':

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -17,16 +17,16 @@ from tests.cdblib_test import testdata_path
 class CompatTests(unittest.TestCase):
     def setUp(self):
         self.temp_dir = mkdtemp()
-        self.cdb_path = join(self.temp_dir, 'database.cdb')
+        self.cdb_path = join(self.temp_dir, 'database.cd')
         self.tmp_path = join(self.temp_dir, 'database.tmp')
 
         self.db = cdb.cdbmake(
             self.cdb_path.encode('utf-8'), self.tmp_path.encode('utf-8')
         )
-        self.db.add(b'a', b'1')
-        self.db.add(b'a', b'2')
-        self.db.addmany([(b'b', b'1'), (b'c', b'1')])
-        self.db.add(b'a', b'3')
+        self.db.add('a', '1')
+        self.db.add('a', '2')
+        self.db.addmany([('b', '1'), ('c', '1')])
+        self.db.add('a', b'\x80')
 
     def tearDown(self):
         rmtree(self.temp_dir, ignore_errors=False)
@@ -34,6 +34,10 @@ class CompatTests(unittest.TestCase):
     def _get_reader(self):
         self.db.finish()
         return cdb.init(self.cdb_path.encode('utf-8'))
+
+    def test_add(self):
+        self.db.add('a', '4')
+        self.db.add('a', '4')
 
     def test_numentries(self):
         self.assertEqual(self.db.numentries, 5)
@@ -46,26 +50,26 @@ class CompatTests(unittest.TestCase):
 
     def test_each(self):
         reader = self._get_reader()
-        self.assertEqual(reader.each(), (b'a', b'1'))
-        self.assertEqual(reader.each(), (b'a', b'2'))
-        self.assertEqual(reader.each(), (b'b', b'1'))
-        self.assertEqual(reader.each(), (b'c', b'1'))
-        self.assertEqual(reader.each(), (b'a', b'3'))
+        self.assertEqual(reader.each(), ('a', '1'))
+        self.assertEqual(reader.each(), ('a', '2'))
+        self.assertEqual(reader.each(), ('b', '1'))
+        self.assertEqual(reader.each(), ('c', '1'))
+        self.assertEqual(reader.each(), ('a', b'\x80'))
         self.assertIsNone(reader.each())
-        self.assertEqual(reader.each(), (b'a', b'1'))
+        self.assertEqual(reader.each(), ('a', '1'))
 
     def test_firstkey(self):
         reader = self._get_reader()
-        self.assertEqual(reader.firstkey(), b'a')
-        self.assertEqual(reader.nextkey(), b'b')
-        self.assertEqual(reader.firstkey(), b'a')
-        self.assertEqual(reader.nextkey(), b'b')
+        self.assertEqual(reader.firstkey(), 'a')
+        self.assertEqual(reader.nextkey(), 'b')
+        self.assertEqual(reader.firstkey(), 'a')
+        self.assertEqual(reader.nextkey(), 'b')
 
     def test_nextkey(self):
         reader = self._get_reader()
-        self.assertEqual(reader.nextkey(), b'a')
-        self.assertEqual(reader.nextkey(), b'b')
-        self.assertEqual(reader.nextkey(), b'c')
+        self.assertEqual(reader.nextkey(), 'a')
+        self.assertEqual(reader.nextkey(), 'b')
+        self.assertEqual(reader.nextkey(), 'c')
         self.assertIsNone(reader.nextkey())
         self.assertIsNone(reader.nextkey())
 

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+from __future__ import division, print_function, unicode_literals
+import unittest
+
+from os.path import exists, join
+from shutil import rmtree
+from tempfile import mkdtemp
+
+try:
+    import cdb
+except ImportError:
+    import cdblib.compat as cdb
+
+from tests.cdblib_test import testdata_path
+
+
+class CompatTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = mkdtemp()
+        self.cdb_path = join(self.temp_dir, 'database.cdb')
+        self.tmp_path = join(self.temp_dir, 'database.tmp')
+
+        self.db = cdb.cdbmake(
+            self.cdb_path.encode('utf-8'), self.tmp_path.encode('utf-8')
+        )
+        self.db.add(b'a', b'1')
+        self.db.add(b'a', b'2')
+        self.db.addmany([(b'b', b'1'), (b'c', b'1')])
+        self.db.add(b'a', b'3')
+
+    def tearDown(self):
+        rmtree(self.temp_dir, ignore_errors=False)
+
+    def _get_reader(self):
+        self.db.finish()
+        return cdb.init(self.cdb_path.encode('utf-8'))
+
+    def test_numentries(self):
+        self.assertEqual(self.db.numentries, 5)
+        self.db.finish()
+        self.assertEqual(self.db.numentries, 5)
+
+    def test_finish(self):
+        self.db.finish()
+        self.assertFalse(exists(self.tmp_path))
+
+    def test_each(self):
+        reader = self._get_reader()
+        self.assertEqual(reader.each(), (b'a', b'1'))
+        self.assertEqual(reader.each(), (b'a', b'2'))
+        self.assertEqual(reader.each(), (b'b', b'1'))
+        self.assertEqual(reader.each(), (b'c', b'1'))
+        self.assertEqual(reader.each(), (b'a', b'3'))
+        self.assertIsNone(reader.each())
+        self.assertEqual(reader.each(), (b'a', b'1'))
+
+    def test_firstkey(self):
+        reader = self._get_reader()
+        self.assertEqual(reader.firstkey(), b'a')
+        self.assertEqual(reader.nextkey(), b'b')
+        self.assertEqual(reader.firstkey(), b'a')
+        self.assertEqual(reader.nextkey(), b'b')
+
+    def test_nextkey(self):
+        reader = self._get_reader()
+        self.assertEqual(reader.nextkey(), b'a')
+        self.assertEqual(reader.nextkey(), b'b')
+        self.assertEqual(reader.nextkey(), b'c')
+        self.assertIsNone(reader.nextkey())
+        self.assertIsNone(reader.nextkey())
+
+    def test_size(self):
+        reader = self._get_reader()
+        self.assertEqual(reader.size, 2178)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -50,44 +50,32 @@ class CompatTests(unittest.TestCase):
 
     def test_each(self):
         reader = self._get_reader()
-        try:
-            self.assertEqual(reader.each(), ('a', '1'))
-            self.assertEqual(reader.each(), ('a', '2'))
-            self.assertEqual(reader.each(), ('b', '1'))
-            self.assertEqual(reader.each(), ('c', '1'))
-            self.assertEqual(reader.each(), ('a', b'\x80'))
-            self.assertIsNone(reader.each())
-            self.assertEqual(reader.each(), ('a', '1'))
-        finally:
-            reader._file_obj.close()
+        self.assertEqual(reader.each(), ('a', '1'))
+        self.assertEqual(reader.each(), ('a', '2'))
+        self.assertEqual(reader.each(), ('b', '1'))
+        self.assertEqual(reader.each(), ('c', '1'))
+        self.assertEqual(reader.each(), ('a', b'\x80'))
+        self.assertIsNone(reader.each())
+        self.assertEqual(reader.each(), ('a', '1'))
 
     def test_firstkey(self):
         reader = self._get_reader()
-        try:
-            self.assertEqual(reader.firstkey(), 'a')
-            self.assertEqual(reader.nextkey(), 'b')
-            self.assertEqual(reader.firstkey(), 'a')
-            self.assertEqual(reader.nextkey(), 'b')
-        finally:
-            reader._file_obj.close()
+        self.assertEqual(reader.firstkey(), 'a')
+        self.assertEqual(reader.nextkey(), 'b')
+        self.assertEqual(reader.firstkey(), 'a')
+        self.assertEqual(reader.nextkey(), 'b')
 
     def test_nextkey(self):
         reader = self._get_reader()
-        try:
-            self.assertEqual(reader.nextkey(), 'a')
-            self.assertEqual(reader.nextkey(), 'b')
-            self.assertEqual(reader.nextkey(), 'c')
-            self.assertIsNone(reader.nextkey())
-            self.assertIsNone(reader.nextkey())
-        finally:
-            reader._file_obj.close()
+        self.assertEqual(reader.nextkey(), 'a')
+        self.assertEqual(reader.nextkey(), 'b')
+        self.assertEqual(reader.nextkey(), 'c')
+        self.assertIsNone(reader.nextkey())
+        self.assertIsNone(reader.nextkey())
 
     def test_size(self):
         reader = self._get_reader()
-        try:
-            self.assertEqual(reader.size, 2178)
-        finally:
-            reader._file_obj.close()
+        self.assertEqual(reader.size, 2178)
 
 
 if __name__ == '__main__':

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -57,7 +57,6 @@ class CompatTests(object):
     def test_finish(self):
         self.db.finish()
         self.assertFalse(exists(self.tmp_path))
-        self.db.finish()
 
     def test_get(self):
         reader = self._get_reader()
@@ -127,6 +126,7 @@ class PythonCDBTests(CompatTests, unittest.TestCase):
 class PythonPureCDBTests(CompatTests, unittest.TestCase):
     def test_cdbmake_cleanup(self):
         # Cleanup after close - no exception
+        self.db.finish()
         self.db.finish()
         self.db._cleanup()
 

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -37,7 +37,9 @@ class CompatTests(unittest.TestCase):
 
     def test_add(self):
         self.db.add('a', '4')
+        self.assertEqual(self.db.numentries, 6)
         self.db.add('a', '4')
+        self.assertEqual(self.db.numentries, 7)
 
     def test_numentries(self):
         self.assertEqual(self.db.numentries, 5)
@@ -47,6 +49,29 @@ class CompatTests(unittest.TestCase):
     def test_finish(self):
         self.db.finish()
         self.assertFalse(exists(self.tmp_path))
+
+    def test_get(self):
+        reader = self._get_reader()
+        self.assertEqual(reader.get('a'), '1')
+        self.assertEqual(reader.get('a', 1), '2')
+        self.assertEqual(reader.get('a', 2), b'\x80')
+        self.assertEqual(reader.get('a', 3), None)
+
+    def test_getitem(self):
+        reader = self._get_reader()
+        self.assertEqual(reader['a'], '1')
+        self.assertEqual(reader['b'], '1')
+        self.assertEqual(reader['c'], '1')
+
+        with self.assertRaises(KeyError):
+            reader['d']
+
+    def test_getall(self):
+        reader = self._get_reader()
+        self.assertEqual(reader.getall('a'), ['1', '2', b'\x80'])
+        self.assertEqual(reader.getall('b'), ['1'])
+        self.assertEqual(reader.getall('c'), ['1'])
+        self.assertEqual(reader.getall('d'), [])
 
     def test_each(self):
         reader = self._get_reader()
@@ -73,8 +98,9 @@ class CompatTests(unittest.TestCase):
         self.assertIsNone(reader.nextkey())
         self.assertIsNone(reader.nextkey())
 
-    def test_size(self):
+    def test_name_size(self):
         reader = self._get_reader()
+        self.assertEqual(reader.name, self.cdb_path)
         self.assertEqual(reader.size, 2178)
 
 


### PR DESCRIPTION
This PR adds a new module for use in migrating applications that use `python-cdb` to Python 3.

The `python-cdb` package provides cdb writing and reading capabilities similar to this module's, using a C extension that only works on Python 2. The new module is intended to be more-or-less a drop-in replacement for that package.

The docs page describes the interface, and the tests are written such that they can run on Python 2 with the `python-cdb` package installed. There are a few caveats, especially around encoding, but my hope is that this module makes switching very easy.