### PR TITLE
Alternate constructors for the Reader classes

### DIFF
--- a/docs/library.rst
+++ b/docs/library.rst
@@ -8,16 +8,29 @@ The `Reader` classes
 `cdbmake` CLI tool. `cdblib.Reader64` reads "64-bit" cdb files, which can be
 produced by this package.
 
-The `Reader` classes take one positional argument, a `bytes`-like object with
-a database's content:
+The `Reader` classes can be instantiated by passing one positional argument,
+a `bytes`-like object with a database's content:
 
     >>> import cdblib
     >>> with open('info.cdb', 'rb') as f:
     ...     data = f.read()
     >>> reader = cdblib.Reader(data)
 
-An `mmap` object can be used to avoid reading an entire database into memory -
-see below.
+Alternatively, you can use the ``Reader`` classes as a context manager and
+give either a file path or a file-like object.
+
+    >>> with cdblib.Reader.from_file_path('info.cdb') as reader:
+    ...    print(reader.items())
+
+    >>> with open('info.cdb', 'rb') as f:
+    ...     with cdblib.Reader.from_file_obj(f) as reader:
+    ...         print(reader.items())
+
+When using the `.from_file_path()` or `.from_file_obj()` constructors, a
+memory-mapped file object is created. This keeps the whole database from
+being read into memory. See the
+`Python docs <https://docs.python.org/3/library/mmap.html>`_ for more
+information on `mmap`.
 
 Retrieving data
 ^^^^^^^^^^^^^^^
@@ -141,24 +154,6 @@ deal with `bytes` keys only.
     >>> reader.get(1)
     ...
     TypeError: key must be of type 'bytes'
-
-
-Limiting memory usage
-^^^^^^^^^^^^^^^^^^^^^
-
-To avoid having to read a whole database into memory, use `cdblib.Reader`
-(or `cdblib.Reader64`) with `mmap.mmap`.
-
-    >>> from mmap import mmap, ACCESS_READ
-    ... from cdblib import Reader
-    ...
-    ... with open('info.cdb', 'rb') as f:
-    ...     with mmap(f.fileno(), 0, access=ACCESS_READ) as m:
-    ...         reader = Reader(m)
-    ...         reader.items()
-
-See the `Python docs <https://docs.python.org/3/library/mmap.html>`_ for more
-information on `mmap`.
 
 The `Writer` classes
 --------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,6 +38,12 @@ To retrieve the first value stored at a key, use the `.get()` method.
 Note that all keys and values are `bytes` objects.
 For more information, see the library documentation.
 
+You may also construct a `Reader` instance with a file path.
+Use a `with` block to automatically close the file:
+
+    >>> with cdblib.Reader.from_file_path('info.cdb', 'rb') as reader:
+    ...    pass  # Do your thing here
+
 For "64-bit" database files, use `cdblib.Reader64` instead of `cdblib.Reader`.
 
 Writing new cdb files


### PR DESCRIPTION
This is PR #30, without the changes to the read algorithm.

The `Reader` classes can now act as context managers, and can be called one of three ways:

The old way - with the database in memory:
```python
with open('info.cdb', 'rb') as f:
    data = f.read()
reader = cdblib.Reader64(data)
sum(1 for k in set(reader.iterkeys()))
```

Using a file path:
```python
with cdblib.Reader64.from_file_path('info.cdb') as reader:
    sum(1 for k in set(reader.iterkeys()))
```

Using a file object:
```python
with open('info.cdb', 'rb') as f:
    reader = cdblib.Reader64.from_file_obj(file_obj=f)
    sum(1 for k in set(reader.iterkeys()))
```

The new constructors use `mmap` automatically, and the docs have been updated such that they no longer recommend doing this manually.