### PR TITLE
Test on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: "python"
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 script:
     - "coverage run --include='cdblib/*.py' setup.py test"
     - "flake8 ."
-    - "coverage erase"
 
 notifications:
     - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script:
     - "coverage run --include='cdblib/*.py' setup.py test"
     - "flake8 ."
+    - "coverage erase"
 
 notifications:
     - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ dist: xenial
 language: "python"
 
 python:
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"
-    - "3.8-dev"
-    - "pypy3.5-6.0"
+    - "3.8"
+    - "pypy3"
 
 env:
     - ENABLE_DJB_HASH_CEXT=0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import Extension, find_packages, setup
 
 # Opt-in to building the C extension by setting the
 # ENABLE_DJB_HASH_CEXT environment variable
-if environ.get('ENABLE_DJB_HASH_CEXT'):
+if environ.get('ENABLE_DJB_HASH_CEXT', '1') != '0':
     ext_modules = [
         Extension('cdblib._djb_hash', sources=['cdblib/_djb_hash.c']),
     ]


### PR DESCRIPTION
This PR updates the tests to catch Python 3.8 (and the latest PyPy3). It drops testing for 3.4.