### PR TITLE
Handle "zero" hash values in Reader.gets

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.1, pypy3]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/test_cdblib.py
+++ b/tests/test_cdblib.py
@@ -480,6 +480,17 @@ class WriterNativeInterfaceTestBase(object):
         ]:
             with self.assertRaises(exc_type):
                 self.writer.putstrings(key, value)
+    
+    def test_zero_hash(self):
+        # Adapted from https://github.com/bbayles/python-pure-cdb/issues/39
+        key1 = b'xyz'
+        key2 = bytes([*[13, 168, 240, 240, 64, 64, 128, 128, 128, 0, 128, 128, 0, 0, 0, 128, 128], *([0] * 692791), 128])  # noqa
+        value = b'abc'
+        self.writer.put(key1, value)
+        self.writer.put(key2, value)
+        reader = self.get_reader()
+        self.assertEqual(reader.get(key1), value)
+        self.assertEqual(reader.get(key2), value)
 
 
 class WriterNativeInterfaceDjbHashTestCase(WriterNativeInterfaceTestBase,


### PR DESCRIPTION
Fixes issue #39 

This PR re-works the `Reader.gets` function such that the problem identified in the issue no longer occurs.

I've renamed the variables and cited the DJB spec throughout the function, which at least makes it clearer for me.