### PR TITLE
Test on 3.12

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-rc.1", "pypy-3.8"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,27 @@
+# What we want
+Sphinx==6.2.1
+
+# What we get
+alabaster==0.7.13
+Babel==2.12.1
+certifi==2023.7.22
+charset-normalizer==3.2.0
+docutils==0.19
+idna==3.4
+imagesize==1.4.1
+importlib-metadata==6.8.0
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+packaging==23.1
+Pygments==2.16.1
+pytz==2023.3
+requests==2.31.0
+snowballstemmer==2.2.0
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+urllib3==2.0.4
+zipp==3.16.2


### PR DESCRIPTION
This PR updates the GHA testing list to include 3.12.0-rc1. It also drops testing for 3.7, which is EOL.